### PR TITLE
Downgraded app to net 8

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>
@@ -9,16 +9,16 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,19 +67,24 @@ WORKDIR /app
 # Copy published files from build stage
 COPY --from=build /app/publish .
 
-# Add non-root user for security
-RUN adduser --disabled-password --gecos "" appuser \
-    && chown -R appuser:appuser /app
+# Create directory for certificates
+RUN mkdir -p /https && \
+    adduser --disabled-password --gecos "" appuser && \
+    chown -R appuser:appuser /app && \
+    chown -R appuser:appuser /https
 
 # Configure environment
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV ASPNETCORE_URLS=http://+:80;https://+:443 \
     DOTNET_RUNNING_IN_CONTAINER=true \
-    ASPNETCORE_ENVIRONMENT=Production
+    ASPNETCORE_ENVIRONMENT=Production \
+    ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx \
+    ASPNETCORE_Kestrel__Certificates__Default__Password=YourSecurePassword123!
 
 ENV DOCKER_RUNNING=true
 
-# Expose port
+# Expose ports
 EXPOSE 80
+EXPOSE 443
 
 # Switch to non-root user
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
 # Copy only solution and project files first
@@ -23,7 +23,7 @@ RUN dotnet build "API/API.csproj" -c Release -o /app/build
 RUN dotnet publish "API/API.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 # Development stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS development
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS development
 WORKDIR /app
 
 # Copy solution and project files
@@ -50,7 +50,7 @@ WORKDIR /app/API
 ENV DOTNET_USE_POLLING_FILE_WATCHER=1 \
     ASPNETCORE_ENVIRONMENT=Development \
     ASPNETCORE_URLS=http://+:80 \
-    ASPNETCORE_Kestrel__Endpoints__Http__Url=http://+:80
+    ASPNETCORE_Kestrel__EndpointDefaults__Protocols=Http1
 
 ENV DOCKER_RUNNING=true
 
@@ -61,7 +61,7 @@ EXPOSE 80
 ENTRYPOINT ["dotnet", "watch", "run", "--no-restore", "--urls", "http://+:80"]
 
 # Production stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS production
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS production
 WORKDIR /app
 
 # Copy published files from build stage

--- a/Tests/API.FunctionalTests/API.FunctionalTests.csproj
+++ b/Tests/API.FunctionalTests/API.FunctionalTests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/API.IntegrationTests/API.IntegrationTests.csproj
+++ b/Tests/API.IntegrationTests/API.IntegrationTests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/API.PerformanceTests/API.PerformanceTests.csproj
+++ b/Tests/API.PerformanceTests/API.PerformanceTests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="NBench" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NBomber" Version="5.8.2" />
-    <PackageReference Include="NBomber.Http" Version="5.2.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NBomber" Version="5.5.0" />
+    <PackageReference Include="NBomber.Http" Version="5.0.1" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/API.UnitTests/API.UnitTests.csproj
+++ b/Tests/API.UnitTests/API.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,14 +9,14 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,14 @@ services:
       - "8800:443"
     networks:
       - qauth-network
+    volumes:
+      - ${HOME}/.aspnet/https:/https/
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_URLS=http://+:80;https://+:443
       - ASPNETCORE_HTTPS_PORT=8800
+      - ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx
+      - ASPNETCORE_Kestrel__Certificates__Default__Password=YourSecurePassword123!
       - DOCKER_RUNNING=true
       - ConnectionStrings__DefaultConnection=Host=db;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
     depends_on:


### PR DESCRIPTION
This pull request includes several changes to downgrade the .NET version from 9.0 to 8.0 across multiple project files, Docker configurations, and test projects. Additionally, it introduces HTTPS support in the Docker configuration.

### Downgrade .NET Version:

* [`API/API.csproj`](diffhunk://#diff-10f643f3f94aa596cd0c7088e0160b4e80fc3344882404e032e72d49391ba361L4-R21): Changed the target framework from `net9.0` to `net8.0` and downgraded several package references to compatible versions.
* [`Tests/API.FunctionalTests/API.FunctionalTests.csproj`](diffhunk://#diff-bc902b0be58a92a415c9f8ce80bcd03f6cb80080f6888e4a599f1e3cbe672e54L4-R17): Changed the target framework from `net9.0` to `net8.0` and downgraded several package references to compatible versions.
* [`Tests/API.IntegrationTests/API.IntegrationTests.csproj`](diffhunk://#diff-bc902b0be58a92a415c9f8ce80bcd03f6cb80080f6888e4a599f1e3cbe672e54L4-R17): Changed the target framework from `net9.0` to `net8.0` and downgraded several package references to compatible versions.
* [`Tests/API.PerformanceTests/API.PerformanceTests.csproj`](diffhunk://#diff-6bc6b7462a94313284d42ae7805f3e10ef6db0d9209b1db266d3b9494128fe77L4-R18): Changed the target framework from `net9.0` to `net8.0` and downgraded several package references to compatible versions.
* [`Tests/API.UnitTests/API.UnitTests.csproj`](diffhunk://#diff-2f2c58c66751048bf272d839fa66d31b272326de4d3368bb27c3e2bec5a738b5L4-R19): Changed the target framework from `net9.0` to `net8.0` and downgraded several package references to compatible versions.

### Docker Configuration Updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R4): Updated the base images from `dotnet/sdk:9.0` and `dotnet/aspnet:9.0` to `dotnet/sdk:8.0` and `dotnet/aspnet:8.0`. Introduced HTTPS support by creating a directory for certificates and exposing port 443. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R4) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L26-R26) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L53-R53) [[4]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L64-R87)

### Docker Compose Updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R16-R23): Added volume mapping for HTTPS certificates and updated environment variables to configure HTTPS support.